### PR TITLE
Refactor URLSession to use sharedEphemeral configuration

### DIFF
--- a/Sources/locgen-swift/DownloadManager.swift
+++ b/Sources/locgen-swift/DownloadManager.swift
@@ -17,7 +17,7 @@ class DownloadManager {
     }
     
     func enqueue(url: URL, id: String) {
-        let task = URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
+        let task = URLSession.sharedEphemeral.dataTask(with: url) { [weak self] data, response, error in
             guard let self = self else {
                 return
             }

--- a/Sources/locgen-swift/URLEphemeralSession.swift
+++ b/Sources/locgen-swift/URLEphemeralSession.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  URLEphemeralSession.swift
 //  
 //
 //  Created by Łukasz Szyszkowski on 26/05/2023.

--- a/Sources/locgen-swift/URLEphemeralSession.swift
+++ b/Sources/locgen-swift/URLEphemeralSession.swift
@@ -1,0 +1,12 @@
+//
+//  File.swift
+//  
+//
+//  Created by Łukasz Szyszkowski on 26/05/2023.
+//
+
+import Foundation
+
+extension URLSession {
+    static let sharedEphemeral = URLSession(configuration: .ephemeral)
+}

--- a/Sources/locgen-swift/URLSession+Extensions .swift
+++ b/Sources/locgen-swift/URLSession+Extensions .swift
@@ -1,5 +1,5 @@
 //
-//  URLEphemeralSession.swift
+//  URLSession+Extensions .swift
 //  
 //
 //  Created by Łukasz Szyszkowski on 26/05/2023.


### PR DESCRIPTION
This commit refactors the URLSession in DownloadManager.swift to use the sharedEphemeral configuration instead of the default shared session. It also adds a new file, URLEphemeralSession.swift, which defines an extension for URLSession that creates a shared ephemeral session.