### PR TITLE
Fix double-escaping of already escaped quotes

### DIFF
--- a/Sources/locgen-swift/ParserXLSX.swift
+++ b/Sources/locgen-swift/ParserXLSX.swift
@@ -165,7 +165,7 @@ class ParserXLSX {
                 try deleteFile(at: fileURL)
             }
             
-            let escapedTranslation = translation.replacingOccurrences(of: "\"", with: "\\\"")
+            let escapedTranslation = escapeQuotes(in: translation)
             let textLine = "\"\(key)\" = \"\(escapedTranslation)\";\n"
             
             try append(line: textLine, to: fileURL)
@@ -204,5 +204,34 @@ class ParserXLSX {
         for(fileURL, content) in fileContent {
             FileManager.default.createFile(atPath: fileURL.path, contents: content.data(using: .utf8), attributes: nil)
         }
+    }
+    
+    private func escapeQuotes(in text: String) -> String {
+        // Manually iterate through string to avoid double-escaping already escaped quotes
+        var result = ""
+        var i = text.startIndex
+        
+        while i < text.endIndex {
+            let char = text[i]
+            
+            if char == "\"" {
+                // Check if this quote is already escaped (preceded by \)
+                let isEscaped = i > text.startIndex && text[text.index(before: i)] == "\\"
+                
+                if isEscaped {
+                    // Already escaped, keep as-is
+                    result.append(char)
+                } else {
+                    // Not escaped, escape it
+                    result.append("\\\"")
+                }
+            } else {
+                result.append(char)
+            }
+            
+            i = text.index(after: i)
+        }
+        
+        return result
     }
 }

--- a/Tests/locgen-swiftTests/locgen_swiftTests.swift
+++ b/Tests/locgen-swiftTests/locgen_swiftTests.swift
@@ -40,9 +40,56 @@ final class locgen_swiftTests: XCTestCase {
         ]
         
         for (original, expected) in testTranslations {
-            let escaped = original.replacingOccurrences(of: "\"", with: "\\\"")
+            let escaped = escapeQuotes(in: original)
             XCTAssertEqual(escaped, expected, "Failed to escape quotes in: \(original)")
         }
+    }
+    
+    func testAlreadyEscapedQuotes() throws {
+        let testCases = [
+            // Already escaped quotes should not be double-escaped
+            "Text with \\\"already escaped\\\" quotes": "Text with \\\"already escaped\\\" quotes",
+            "Mixed \\\"escaped\\\" and \"unescaped\" quotes": "Mixed \\\"escaped\\\" and \\\"unescaped\\\" quotes",
+            "<a href=\\\"mailto:kp@wearmedicine.com\\\">Email</a>": "<a href=\\\"mailto:kp@wearmedicine.com\\\">Email</a>",
+            "Only \"unescaped\" quotes": "Only \\\"unescaped\\\" quotes",
+            "No quotes at all": "No quotes at all",
+            "\\\"All already escaped\\\"": "\\\"All already escaped\\\"",
+            "Complex: \\\"escaped\\\" and \"unescaped\" mixed": "Complex: \\\"escaped\\\" and \\\"unescaped\\\" mixed"
+        ]
+        
+        for (input, expected) in testCases {
+            let result = escapeQuotes(in: input)
+            XCTAssertEqual(result, expected, "Failed for input: \(input)")
+        }
+    }
+    
+    private func escapeQuotes(in text: String) -> String {
+        // Manually iterate through string to avoid double-escaping already escaped quotes
+        var result = ""
+        var i = text.startIndex
+        
+        while i < text.endIndex {
+            let char = text[i]
+            
+            if char == "\"" {
+                // Check if this quote is already escaped (preceded by \)
+                let isEscaped = i > text.startIndex && text[text.index(before: i)] == "\\"
+                
+                if isEscaped {
+                    // Already escaped, keep as-is
+                    result.append(char)
+                } else {
+                    // Not escaped, escape it
+                    result.append("\\\"")
+                }
+            } else {
+                result.append(char)
+            }
+            
+            i = text.index(after: i)
+        }
+        
+        return result
     }
 
     /// Returns path to the built products directory.


### PR DESCRIPTION
## Summary
- Implement smart quote escaping that prevents double-escaping of already escaped quotes
- Replace naive string replacement with character-by-character analysis 
- Add comprehensive tests for mixed escaped/unescaped quote scenarios

## Problem
The previous quote escaping implementation would double-escape quotes that were already escaped by users in XLSX files. For example:
- Input: `<a href=\"mailto:kp@wearmedicine.com\">`
- Previous output: `<a href=\\\"mailto:kp@wearmedicine.com\\\">` ❌ (double-escaped)
- New output: `<a href=\"mailto:kp@wearmedicine.com\">` ✅ (correctly preserved)

## Solution  
The new `escapeQuotes` function:
1. Iterates character by character through the translation text
2. For each quote (`"`), checks if it's preceded by a backslash (`\`)
3. Only escapes quotes that are NOT already escaped
4. Preserves already escaped quotes as-is

## Test Coverage
- ✅ Simple unescaped quotes: `"text"` → `\"text\"`
- ✅ Already escaped quotes: `\"text\"` → `\"text\"` (unchanged)
- ✅ Mixed scenarios: `\"escaped\" and "unescaped"` → `\"escaped\" and \"unescaped\"`
- ✅ HTML attributes: `href=\"mailto:...\"` → preserved correctly
- ✅ Complex mixed cases with multiple quote types

This prevents malformed .strings files and handles real-world scenarios where users pre-escape quotes in their XLSX data.

🤖 Generated with [Claude Code](https://claude.ai/code)