### PR TITLE
Remove debug logging from XLSX parser

### DIFF
--- a/Sources/locgen-swift/ParserXLSX.swift
+++ b/Sources/locgen-swift/ParserXLSX.swift
@@ -97,19 +97,12 @@ class ParserXLSX {
         }
         
         var isFirstRow = true
-        var processedKeys: [String] = []
-        var skippedRows = 0
-        
-        print("🔍 Processing \(data.rows.count - 1) data rows...")
         
         for i in 1..<data.rows.count {
             let row = data.rows[i]
             let keyCell = row.cells.first(where: { cell in return cell.reference.column.value == mainKeyRef.value })
             
             if let keyvalue = extractValue(from: keyCell, sharedStrings: sharedStrings), !keyvalue.isEmpty {
-                print("✅ Processing key: '\(keyvalue)'")
-                processedKeys.append(keyvalue)
-                
                 try updateStrings(
                     key: keyvalue,
                     row: row,
@@ -122,14 +115,9 @@ class ParserXLSX {
                 )
                 
                 isFirstRow = false
-            } else {
-                skippedRows += 1
-                let keyValue = keyCell?.value ?? "nil"
-                print("⏭️ Skipping row \(i): key cell value = '\(keyValue)' (empty or nil)")
             }
         }
         
-        print("📊 Summary: Processed \(processedKeys.count) keys, skipped \(skippedRows) rows")
         
         writeData()
     }


### PR DESCRIPTION
## Summary
Clean up verbose console output that was added during debugging the rich text extraction fix.

## Changes
- ❌ Remove processing progress messages (`🔍 Processing X data rows...`)
- ❌ Remove individual key processing logs (`✅ Processing key: 'xyz'`) 
- ❌ Remove row skipping notifications (`⏭️ Skipping row X`)
- ❌ Remove summary statistics (`📊 Summary: Processed X keys`)

## What's Preserved
✅ The rich text extraction functionality remains intact
✅ All core XLSX parsing logic unchanged
✅ Error handling and edge cases still work

## Rationale
The verbose logging was useful for debugging the shared string rich text issue but creates too much noise for normal production use. Users expect clean, minimal output from CLI tools.

## Testing
- [x] Tool compiles successfully
- [x] Rich text extraction still works (core functionality preserved)
- [x] Clean, quiet output for normal usage